### PR TITLE
fix: fix EvaluationResult attribute types

### DIFF
--- a/ape/types/__init__.py
+++ b/ape/types/__init__.py
@@ -1,13 +1,11 @@
-from typing import Any, Awaitable, Callable, Dict, List, Tuple, Union
-from .dataset_item import DatasetItem
+from typing import Any, Awaitable, Callable, Dict, Tuple, Union
+from .dataset_item import DatasetItem, DataItem, Dataset
 from .response_format import (
-    ResponseFormat, 
+    ResponseFormat,
     JsonSchema,
 )
 from .eval_result import EvaluationResult, MetricResult, GlobalMetricResult
-DataItem = Union[Dict[str, Any], DatasetItem]
 
-Dataset = Union[List[Dict[str, Any]], List[DatasetItem]]
 
 Evaluator = Callable[
     ..., Awaitable[Tuple[int, DataItem, Union[str, Dict[str, Any], float]]]
@@ -15,6 +13,7 @@ Evaluator = Callable[
 
 
 __all__ = [
+    "DatasetItem",
     "Dataset",
     "DataItem",
     "Evaluator",

--- a/ape/types/dataset_item.py
+++ b/ape/types/dataset_item.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from pydantic import BaseModel, ConfigDict
 
 
@@ -8,3 +8,8 @@ class DatasetItem(BaseModel):
     metadata: Optional[Dict[str, Any]] = None
 
     model_config = ConfigDict(extra="ignore")
+
+
+DataItem = Union[Dict[str, Any], DatasetItem]
+
+Dataset = Union[List[Dict[str, Any]], List[DatasetItem]]

--- a/ape/types/eval_result.py
+++ b/ape/types/eval_result.py
@@ -1,16 +1,21 @@
 from pydantic import BaseModel
 from typing import Any, Dict, Optional, Union
 
+from ape.types.dataset_item import DataItem
+
+
 class EvaluationResult(BaseModel):
-    example: Union[dict, str]
-    prediction: Union[dict, str]
+    example: DataItem
+    prediction: DataItem
     score: float
     intermediate_values: Optional[Dict[str, Any]] = None
-    
+
+
 class MetricResult(BaseModel):
     score: float
     intermediate_values: Optional[Dict[str, Any]] = None
-    
+
+
 class GlobalMetricResult(BaseModel):
     score: float
     metadata: Optional[Dict[str, Any]] = None

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="ape-core",
-    version="0.7.3",
+    version="0.7.4",
     packages=find_namespace_packages(),
     include_package_data=True,
     entry_points={},


### PR DESCRIPTION
## Issue
![image](https://github.com/user-attachments/assets/b04d88cf-f945-44ff-a92a-547b77506eb2)
* `example`, `prediction` of `EvaluationResult` should be a `DataItem` type, not `union[dict, str]`

## Changes
`union[dict, str]` -> `DataItem`
