### PR TITLE
chore: change promptfile dependency in pyproject.toml, bump version 0…

### DIFF
--- a/libs/ape-common/pyproject.toml
+++ b/libs/ape-common/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pydantic>=2.9.2",
     "pandas>=2.2.3",
     "litellm>=1.48.0",
-    "promptfile>=0.5.0",
+    "promptfile>=0.6.0",
     "structlog>=23.1.0",
     "rich>=13.0.1",
 ]

--- a/libs/ape-core/pyproject.toml
+++ b/libs/ape-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ape-core"
-version = "0.7.4"
+version = "0.8.0"
 description = "Ape: your AI prompt engineer"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/poetry.lock
+++ b/poetry.lock
@@ -211,7 +211,7 @@ dev = ["black", "pytest"]
 
 [package.source]
 type = "directory"
-url = "libs/common"
+url = "libs/ape-common"
 
 [[package]]
 name = "async-timeout"
@@ -1546,20 +1546,18 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "promptfile"
-version = "0.5.0"
+version = "0.6.0"
 description = "promptfile: language support for .prompt files"
 optional = false
 python-versions = ">=3.8.10"
-files = []
-develop = true
+files = [
+    {file = "promptfile-0.6.0-py3-none-any.whl", hash = "sha256:9fb5dc7c3ab3e623df430a2c2789cf29a3d5f42be47027bc9f1d6ede434d2fff"},
+    {file = "promptfile-0.6.0.tar.gz", hash = "sha256:0d8a860a389a59e6a8cadf39f4f2107af7150d5d46c4bdfaf90afa37774f697c"},
+]
 
 [package.dependencies]
 pydantic = "*"
 pyyaml = "*"
-
-[package.source]
-type = "directory"
-url = "../promptfile"
 
 [[package]]
 name = "psycopg2-binary"
@@ -2674,4 +2672,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "bf0c7ef2542030a794b6181e66823c9ec27bab1e9c8951ebdb419243db9b47be"
+content-hash = "1789036b2787b4c708be5ab191f416627903ff2a3a0b4d1db62c474a1d955f13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ape" 
-version = "0.7.4"
+version = "0.8.0"
 description = "Ape: your AI prompt engineer"
 authors = ["weavel <founders@weavel.ai>"]
 packages = [
@@ -32,7 +32,7 @@ structlog = "^24.4.0"
 litellm = "^1.48.0"
 pandas = "^2.2.3"
 pysbd = "^0.3.4"
-promptfile = {path = "../promptfile", develop = true}  # Moved to the correct section
+promptfile = "^0.6.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
### Description

This pull request updates the `promptfile` dependency and version numbers across multiple files in the project. The main changes include:

1. Upgrading the `promptfile` dependency from `>=0.5.0` to `>=0.6.0` in `libs/ape-common/pyproject.toml`.
2. Bumping the version of `ape-core` from `0.7.4` to `0.8.0` in `libs/ape-core/pyproject.toml`.
3. Updating the `promptfile` package in `poetry.lock` to version `0.6.0`, removing the local development reference.
4. Changing the main project version from `0.7.4` to `0.8.0` in the root `pyproject.toml`.
5. Replacing the local development reference of `promptfile` with the versioned dependency `^0.6.0` in the root `pyproject.toml`.

These changes aim to standardize the `promptfile` dependency across the project and update the project's version to reflect the new changes. This update likely includes new features or bug fixes in the `promptfile` package.

### Changes that Break Backward Compatibility

The upgrade of the `promptfile` dependency from version 0.5.0 to 0.6.0 may introduce breaking changes if there are any incompatibilities between these versions. While this is a minor version change, it's possible that there might be some breaking changes or new features that could affect the project. Users of this project should review the changelog of `promptfile` 0.6.0 to ensure their code remains compatible with the new version and understand any potential impacts.

### Documentation

N/A

*Created with [Palmier](https://www.palmier.io)*

*Created with [Palmier](https://www.palmier.io)*