### PR TITLE
[fix] Update directory path in GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
           pip install build
       - name: Build package
         run: |
-          cd ${{ env.package_dir }}
+          cd ${{ github.workspace }}${{ env.package_dir }}
           python -m build
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### Description

This pull request updates the directory path in the GitHub Actions workflow file `publish.yml`. The change modifies the `cd` command in the "Build package" step to use `${{ github.workspace }}` in conjunction with `${{ env.package_dir }}`. This adjustment ensures that the correct directory is accessed during the package build process, potentially resolving issues related to incorrect working directory in the CI/CD pipeline.

The modification is as follows:
- Old path: ``cd ${{ env.package_dir }}``
- New path: ``cd ${{ github.workspace }}${{ env.package_dir }}``

This change addresses a problem where the workflow was not finding the correct directory to build the package, by explicitly including the GitHub workspace path. Adding ${{ github.workspace }} to the directory path is necessary to navigate to the correct location from where GitHub Actions is executed. This adjustment addresses potential issues with the working directory in the CI/CD pipeline.

### Changes that Break Backward Compatibility
N/A

### Documentation
N/A

Notes: The user clarified that adding ${{ github.workspace }} to the directory path is necessary to navigate to the correct location from where GitHub Actions is executed. This adjustment addresses potential issues with the working directory in the CI/CD pipeline.

*Created with [Palmier](https://www.palmier.io)*