### PR TITLE
[fix] Update package directory path in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          package_directory: ${{ env.package_dir }}
+          package_directory: ${{ github.workspace }}${{ env.package_dir }}/dist


### PR DESCRIPTION
Update the package_directory value in '.github/workflows/publish.yml' to use the full path including the workspace and 'dist' directory.

Notes: This change ensures that the correct directory containing the built distribution files is used during the package publishing process. The addition of '${{ github.workspace }}' and '/dist' to the path provides a more precise location for the package files, which is likely necessary for the PyPI publishing action to function correctly.