### PR TITLE
[fix] Update package directory path in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          package_directory: ${{ github.workspace }}${{ env.package_dir }}/dist
+          packages-dir: ${{ github.workspace }}${{ env.package_dir }}/dist


### PR DESCRIPTION
### Description

This pull request updates the package directory path in the publish workflow file (`.github/workflows/publish.yml`). The change modifies the `pypa/gh-action-pypi-publish` action configuration, replacing the `package_directory` parameter with `packages-dir`. This adjustment is likely made to align with the latest version of the PyPI publish action, ensuring the correct directory is used for package distribution.

The modification is minimal but crucial for the proper functioning of the automated publishing process. By updating this parameter, the workflow will now correctly locate and publish the Python package to PyPI.

### Changes that Break Backward Compatibility

N/A

### Documentation

N/A

*Created with [Palmier](https://www.palmier.io)*