### PR TITLE
[fix] Include *.prompt files in package data

### DIFF
--- a/libs/ape-common/pyproject.toml
+++ b/libs/ape-common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ape-common"
-version = "0.1.0" 
+version = "0.1.1" 
 description = "Common utilities for Ape: your AI prompt engineer"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -36,7 +36,7 @@ include = ["ape*"]
 namespaces = true
 
 [tool.setuptools.package-data]
-"*" = ["*.txt", "*.md"]
+"*" = ["*.txt", "*.md", "*.prompt"]
 
 [project.optional-dependencies]
 dev = [

--- a/libs/ape-core/pyproject.toml
+++ b/libs/ape-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ape-core"
-version = "0.8.0"
+version = "0.8.1"
 description = "Ape: your AI prompt engineer"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -41,7 +41,7 @@ include = ["ape*"]
 namespaces = true
 
 [tool.setuptools.package-data]
-"*" = ["*.txt", "*.md"]
+"*" = ["*.txt", "*.md", "*.prompt"]
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ape" 
-version = "0.8.0"
+version = "0.8.1"
 description = "Ape: your AI prompt engineer"
 authors = ["weavel <founders@weavel.ai>"]
 packages = [


### PR DESCRIPTION
Update pyproject.toml files to include *.prompt files in package data for ape-common and ape-core libraries. Increment version numbers for ape-common (0.1.1), ape-core (0.8.1), and the main project (0.8.1).

Notes: The *.prompt files contain prompts used by the ape libraries. Including them in the package data ensures they will be distributed with the package, allowing users to access and utilize these prompts.

This pull request modifies the `pyproject.toml` files for `ape-common`, `ape-core`, and the main project to include `*.prompt` files in the package data. The changes are implemented by updating the `[tool.setuptools.package-data]` section in the respective `pyproject.toml` files, adding `"*.prompt"` to the list of included file types.

These changes ensure that prompt files, which are essential for the Ape libraries' functionality, are properly distributed with the package.

There are no changes that break backward compatibility, and no additional documentation is required for this update.

*Created with [Palmier](https://www.palmier.io)*