### PR TITLE
[refactor] Update TypedDict import and remove unused imports

### DIFF
--- a/libs/ape-common/ape/common/types/dataset_item.py
+++ b/libs/ape-common/ape/common/types/dataset_item.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Optional, TypedDict, Union
+from typing import Any, Dict, List, Optional, Union
+from typing_extensions import TypedDict
 
 
 class DatasetItem(TypedDict):

--- a/libs/ape-common/pyproject.toml
+++ b/libs/ape-common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ape-common"
-version = "0.1.1" 
+version = "0.1.2" 
 description = "Common utilities for Ape: your AI prompt engineer"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/libs/ape-core/ape/core/optimizer/mipro/mipro.py
+++ b/libs/ape-core/ape/core/optimizer/mipro/mipro.py
@@ -2,7 +2,7 @@ import os
 from collections import defaultdict
 import pickle
 import random
-from typing import Any, Dict, List, Optional, Tuple, Union, TypedDict
+from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 import optuna
 from rich.console import Console

--- a/libs/ape-core/pyproject.toml
+++ b/libs/ape-core/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "ape-common>=0.1.0,<0.2.0",
+    "ape-common>=0.1.2,<0.2.0",
     "optuna>=4.0.0,<5.0.0",
     "psycopg2-binary>=2.9.9,<3.0.0",
     "sqlalchemy>=2.0.35,<3.0.0",


### PR DESCRIPTION
- Move TypedDict import from typing to typing_extensions in dataset_item.py
- Remove unused TypedDict import from mipro.py
- Update ape-common version to 0.1.2
- Update ape-core dependency on ape-common to >=0.1.2,<0.2.0

Notes: The changes were made to resolve an \"Unused TypedDict imported from typing_extensions\" error. The developer sought to remove the unused import to fix the issue, as suggested in the chat history. The TypedDict import was also moved to typing_extensions in dataset_item.py, likely to ensure compatibility across different Python versions.