### PR TITLE
[chore] Update dependencies and version numbers

### DIFF
--- a/libs/ape-common/pyproject.toml
+++ b/libs/ape-common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ape-common"
-version = "0.1.2" 
+version = "0.1.3" 
 description = "Common utilities for Ape: your AI prompt engineer"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -21,7 +21,7 @@ dependencies = [
     "pydantic>=2.9.2",
     "pandas>=2.2.3",
     "litellm>=1.48.0",
-    "promptfile>=0.6.0",
+    "promptfile>=0.7.0",
     "structlog>=23.1.0",
     "rich>=13.0.1",
 ]

--- a/libs/ape-core/pyproject.toml
+++ b/libs/ape-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ape-core"
-version = "0.8.1"
+version = "0.8.2"
 description = "Ape: your AI prompt engineer"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "ape-common>=0.1.2,<0.2.0",
+    "ape-common>=0.1.3,<0.2.0",
     "optuna>=4.0.0,<5.0.0",
     "psycopg2-binary>=2.9.9,<3.0.0",
     "sqlalchemy>=2.0.35,<3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ape" 
-version = "0.8.1"
+version = "0.8.2"
 description = "Ape: your AI prompt engineer"
 authors = ["weavel <founders@weavel.ai>"]
 packages = [


### PR DESCRIPTION
Update version numbers and dependencies across multiple components:
- Bump ape-common from 0.1.2 to 0.1.3
- Update promptfile dependency from >=0.6.0 to >=0.7.0
- Bump ape-core from 0.8.1 to 0.8.2
- Update ape-common dependency in ape-core to >=0.1.3
- Bump main project version from 0.8.1 to 0.8.2

Notes: The update to promptfile 0.7.0 supports Python > 3.10, while the previous version 0.6.0 supported > 3.12. The version updates in ape-core and the main project are due to the dependency changes in ape-common. These coordinated updates ensure compatibility across the Ape project components.