### PR TITLE
[bug fix] Change isinstance to issubclass for response_format check

### DIFF
--- a/libs/ape-common/ape/common/prompt/prompt_base.py
+++ b/libs/ape-common/ape/common/prompt/prompt_base.py
@@ -198,7 +198,9 @@ class Prompt(pf.Prompt):
             if self.response_format["type"] == "text":
                 return res_text
             parsed_outputs: Dict[str, Any]
-            if isinstance(self.response_format, BaseModel):
+            if isinstance(self.response_format, type) and issubclass(
+                self.response_format, BaseModel
+            ):
                 parsed_outputs = json.loads(res_text)
                 parsed_outputs = self.response_format.model_validate(parsed_outputs)
             else:
@@ -285,7 +287,7 @@ class Prompt(pf.Prompt):
         """
 
         response_format_cache = None
-        if isinstance(self.response_format, BaseModel):
+        if isinstance(self.response_format, type) and issubclass(self.response_format, BaseModel):
             response_format_cache = self.response_format
             self.response_format = type_to_response_format_param(self.response_format)
 

--- a/libs/ape-common/pyproject.toml
+++ b/libs/ape-common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ape-common"
-version = "0.2.0" 
+version = "0.2.1" 
 description = "Common utilities for Ape: your AI prompt engineer"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Update the condition in Prompt class to use issubclass instead of isinstance when checking self.response_format against BaseModel. This allows for proper handling of subclasses of BaseModel.

- Modified condition in two locations within prompt_base.py
- Updated version number in pyproject.toml from 0.2.0 to 0.2.1

Notes: The user clarified that self.response_format can be a subclass of BaseModel, not just an instance. This change ensures that the code correctly identifies and processes response formats that inherit from BaseModel.