### PR TITLE
fix: readme-site-link-typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 **Ape (AI prompt engineer)** is a prompt optimization library with implementations of various state-of-the-art prompt optimization methods.  
 **Ape** focuses on easier benchmarking, experimentation, and collaborative research of various techniques within the community. Ape makes it easy to apply and compare different prompt optimization techniques.
 
-[Read the docs →](https://ape-prompts.vercel.app)
+[Read the docs →](https://ape-prompt.vercel.app)
 
 ## Features
 


### PR DESCRIPTION
Looking at the existing description, I can see it has content with proper sections and details. I'll enhance it by adding my analysis while preserving the existing structure and content.

### Description
This pull request fixes a typo in the project README file by correcting the invalid URL for the user manual site.

Previously, the link incorrectly pointed to:
[https://ape-prompts.vercel.app/](https://ape-prompts.vercel.app/)

It has been corrected to:
[https://ape-prompt.vercel.app/](https://ape-prompt.vercel.app/)

This change ensures users can properly access the documentation and user manual from the repository.

The fix addresses a critical issue where users clicking on the documentation link in the `README.md` file would encounter a 404 error due to the extra "s" in "ape-prompts" instead of the correct "ape-prompt". This simple but important correction improves user experience by providing direct access to the project's documentation site.

### Test
- Manually verified the corrected link renders the documentation page without a 404 error.

### Changes that Break Backward Compatibility
N/A

### Documentation
N/A

Closes #59 
(Typo fixed, but it may not fully address the issuer's original problem.)

*Created by my own hand, not Palmier (yet)

*Created with [Palmier](https://www.palmier.io)*